### PR TITLE
V1.1.2

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,201 @@
+# XmlDoc design notes
+
+This document explains how the extraction/rendering framework in `core` actually works, and the
+conventions that `kml` (and, more sparingly, `idml`) build on top of it. It's aimed at someone
+adding a new element type or format module, not at an end user of the library (see
+[README.md](README.md) for that).
+
+## Goals
+
+- **Typed, round-trippable models for the parts of a format worth modeling** — a `case class` per
+  real element, with an `Extractor[T]` to build it from XML and a `Renderer[T]` to serialize it
+  back, such that `render(extract(xml))` is semantically equal to the original.
+- **A generic fallback for everything else** — most real-world document formats have far more
+  structure than any one project needs to model precisely. Rather than a giant sealed hierarchy
+  covering the entire spec, unmodeled content falls through to `GenericElement`, a lossless,
+  untyped tree (see below). `kml` currently models almost everything explicitly (it predates this
+  approach); `idml` deliberately does not, and models new element types incrementally as they turn
+  out to matter (see "Mixed parsing" below).
+- **Verify against real files, not just synthetic ones.** Every non-trivial bug found in this
+  codebase (across several sessions) was found by round-tripping *actual* third-party documents,
+  not by inventing test XML by hand. Synthetic tests are still useful for pinning down a specific
+  case once you know what it is, but they don't reliably *find* cases you didn't think of. See
+  "Testing philosophy" below.
+
+## Module layout
+
+```
+core   - format-agnostic: Extractor[T]/Renderer[T], GenericElement, Zip, misc utilities.
+kml    - a typed model of KML (developers.google.com/kml/documentation/kmlreference), on core.
+kml-it - integration tests for kml against real third-party .kml files. Not aggregated by the
+         root project, so plain `sbt test` stays fast; run explicitly (`sbt kmlIt/test`).
+idml   - early-stage support for Adobe InDesign's IDML format, on core. Uses the generic
+         (GenericElement-first) approach rather than kml's fully-typed one.
+```
+
+`core` has no knowledge of KML or IDML; everything format-specific lives in `kml`/`idml`.
+
+## The `Extractor[T]` / `Renderer[T]` framework
+
+### The type classes
+
+```scala
+trait Extractor[T] { def extract(node: scala.xml.Node): Try[T] }
+trait Renderer[T]   { def render(t: T, format: Format, state: StateR): Try[String] }
+```
+
+Both are ordinary type classes with an implicit instance per type, resolved by the compiler the
+usual way. `MultiExtractor[T]` is the analogous type class for extracting a `Seq[T]` out of a
+`NodeSeq]` (used for polymorphic dispatch — see below).
+
+### Field-naming conventions
+
+A KML element is almost always modeled as one case class per real element, and the *case class
+field names themselves* drive extraction/rendering — there's no separate schema or annotation
+layer. The conventions (all in `core`'s `Extractor.scala`, in `doExtractField`) are:
+
+| Field name shape | Meaning |
+|---|---|
+| `_foo: T` (leading underscore) | an XML *attribute* named `foo`, not a child element |
+| `__foo: T` (double underscore) | an *optional* XML attribute |
+| `` `$`: T `` | the element's own text content |
+| `foo: T` | a required child element named `foo` |
+| `maybeFoo: Option[T]` | an optional child element, tag derived by lowercasing `Foo`'s first letter (i.e. `foo`) — with a fallback to the literal `Foo` form if that's not found (some real KML tags, like `ExtendedData`, are capitalized compounds that don't fit the usual lowerCamelCase convention) |
+| `Foos: Seq[T]` (capitalized, plural-looking) | a sequence of child elements — see `Plural`/`extractChildren` for the literal-tag-first, type-based-fallback logic |
+
+If a field's real tag doesn't derive from its name at all (its tag is always something else
+entirely, or one of *several* possible tags depending on which concrete subtype shows up), don't
+fight the naming convention — see `TagProperties` below.
+
+### The arity ladder
+
+Each case class's `Extractor`/`Renderer` is built by combining one combinator per field, using a
+family of methods named by the count and kind of their fields:
+
+- `extractorN0` / `rendererN` — `N` single-valued (`Extractor`/`Renderer`) fields, no `MultiExtractor` fields, no auxiliary parameter.
+- `extractorNM` / `rendererN` — `N` single-valued fields plus `M` `MultiExtractor`(`Seq[_]`)-valued fields (e.g. `extractorPartial62` = 6 single + 2 `Seq`).
+- `extractorPartialNM` / `rendererNSuper` — as above, plus one *auxiliary* parameter in the case class's second parameter list (see "The auxiliary-parameter pattern" below).
+
+These are generated per-arity rather than via a single generic (e.g. shapeless-style) mechanism —
+deliberately: it's more boilerplate, but every step is visible, debuggable, and doesn't require a
+macro or a dependency to understand. The ladder currently goes up to arity 9 (`FeatureData`, the
+widest case class in `kml`, needed it) — extending it further is mechanical: add one more
+`extractorPartialN`/`renderer N`/`FP.uncurried` overload, each modeled exactly on the one below it
+in the file. Don't reach for a novel approach when one more rung of the existing ladder is needed;
+every arity increase so far has been "copy the previous one, bump the number."
+
+### Polymorphic dispatch: `MultiExtractor`
+
+Many KML elements are really *sealed-trait-like* abstractions — `Feature`, `Geometry`,
+`StyleSelector`, `AbstractView` — where a `Seq[Feature]` in the XML is actually a mix of concrete
+subtypes (`Placemark`, `Folder`, `Document`, ...), each identified by its own tag. `multiExtractorN`
+builds a `MultiExtractor[Seq[T]]` for exactly this case: given `N` subtypes and their tags, it
+builds a `{tag -> Extractor}` lookup table and applies it once over the `NodeSeq`, preserving
+document order (`Extractors.orderedMultiExtractor` is the shared implementation underneath every
+`multiExtractorN`). `rendererSuperN` is the render-side counterpart, dispatching on the runtime
+type via `instanceOf` checks.
+
+**Circular dependencies are common and expected** here — e.g. `Geometry`'s own `MultiExtractor`
+needs `MultiGeometry` (one of `Geometry`'s subtypes), and `MultiGeometry` itself contains
+`Seq[Geometry]`. An eager `val` for either side NPEs (whichever initializes second sees the other
+as `null`); a naive `lazy val` deadlocks (Scala's reentrant lazy-val locking blocks a thread on
+itself if the two both happen to be forced on the same thread during their own initialization). The
+fix used everywhere in this codebase is `MultiExtractor.createLazy` / `Renderer.createLazy` — a
+by-name, deferred wrapper that breaks the initialization cycle. If you add a new mutually-recursive
+pair of types, use the same pattern; don't reinvent it.
+
+### The auxiliary-parameter pattern
+
+Most KML elements share a chunk of common data with their siblings — every `Feature` has a `name`,
+`maybeVisibility`, etc. (`FeatureData`); every `Geometry` has `maybeExtrude`/`maybeAltitudeMode`
+(`GeometryData`). Rather than duplicating those fields on every subtype, the subtype's case class
+declares the shared data as an **auxiliary parameter in its own (second) parameter list**:
+
+```scala
+case class Placemark(Geometry: Seq[Geometry])(val featureData: FeatureData) extends Feature
+```
+
+`extractorPartial[B, T](extractorPartialNM(apply))` extracts the aux `B` (here `FeatureData`)
+first via its own `Extractor[B]`, then applies the resulting `B => T` function; `rendererNSuper`
+is the render-side counterpart. **A subtype must never redeclare one of its aux's own fields as
+its own field** — e.g. don't give `Model` its own `maybeAltitudeMode`, since `GeometryData`
+already provides it to every `Geometry` subtype; doing so renders the same value twice. This
+mistake is easy to make when copying an existing type as a template — double-check the aux's own
+field list before adding a same-named field.
+
+### Escape hatches for irregular real-world XML
+
+Two mechanisms exist specifically for XML that doesn't fit the field-naming convention cleanly:
+
+- **`TagProperties.addMustMatch(tag)`** — forces the *strict* (literal-tag-only, no type-based
+  fallback) extraction path for a specific field name, registered in that type's own companion
+  object. Needed when a field's generic structural fallback (`extractAll`) would otherwise
+  wrongly match a *different*, structurally-identical sibling field (e.g. `InnerBoundaryIs` and
+  `OuterBoundaryIs` are both just a `LinearRing` wrapper, distinguished only by tag — without
+  `addMustMatch`, a `Polygon` with no `<innerBoundaryIs>` at all can spuriously "find" one by
+  matching its own `<outerBoundaryIs>`'s `LinearRing` instead).
+- **`TagProperties.addAliases(field, tags)`** — registers one or more alternate tag names to try,
+  as a last resort, when a field's usual name-derived tag (and its capitalized fallback) both come
+  up empty. Needed when a field's real tag *never* derives from its name at all — e.g.
+  `maybeTimePrimitive`'s real tag is `TimeStamp` or `TimeSpan`, never literally "TimePrimitive".
+
+Both are registered once, in the owning type's own companion object, so they take effect
+automatically the first time anything touches that type's extractor — callers never need to opt
+in explicitly.
+
+### `GenericElement`: the generic fallback
+
+`GenericElement(tag, attributes, children)` (`core`'s `xml` package) is a fully generic,
+lossless representation of an XML element — used two different ways:
+
+1. **As the *entire* content model for a format** (`idml`'s current approach): parse everything
+   into `GenericElement` first, then add specialist types (like `idml`'s `Story`) incrementally,
+   each with its own `fromGenericElement`/`toGenericElement` pair that peels out just the fields
+   worth having real types for, leaving the rest generic. This avoids ever needing to model a
+   whole spec up front just to read one part of it.
+2. **As an ordinary field type within an otherwise fully-typed element** (`kml`'s approach for
+   `TimePrimitive`): when a field is abstract and its concrete shape isn't worth modeling (e.g. its
+   two possible real tags, `TimeStamp`/`TimeSpan`, would otherwise need their own case classes plus
+   a `multiExtractor2`/`rendererSuper2` dispatch pair), just type the field as `Option[GenericElement]`
+   instead. Its `Extractor`/`Renderer` instances make this a drop-in field type like any other.
+
+`GenericElement`'s own `Renderer` is a *leaf* — it renders the value's own `tag`, ignoring
+whatever field name it's nested under, so there's no double-tagging risk regardless of what the
+containing field happens to be called.
+
+## Testing philosophy: round-trip against real files
+
+The single most valuable test in either `kml` or `idml` is: parse a **real** third-party document,
+render it back out, re-parse *that* with `scala.xml.XML.loadString` (a genuine parse — not
+`Utilities.parseUnparsed`, which just wraps its argument as literal unparsed text and never
+actually re-parses anything, and silently made every round-trip test that used it pass regardless
+of correctness), and assert the re-extracted value equals the original extracted value.
+
+This methodology found essentially every real bug fixed in this codebase across every session so
+far — ordering bugs, phantom-match bugs, missing-field crashes, mis-cased tags, attribute-vs-element
+rendering confusion — none of which a hand-written synthetic test happened to exercise. When adding
+a new element type, prefer testing it against a real file over inventing one, and when a synthetic
+test is unavoidable, keep the assertions genuinely round-trip (`extract; render; re-parse; compare
+equal`), not just "did it not throw."
+
+## Adding a new element type: a checklist
+
+Distilled from adding `Model`/`Link`/`NetworkLink`/`ExtendedData`/etc. in `kml`:
+
+1. Define the `case class`, with fields following the naming conventions above. Check whether it
+   needs an auxiliary parameter (is it a subtype of an existing abstraction like `Feature` or
+   `Geometry`?) and, if so, that it doesn't redeclare any of that aux's own fields.
+2. In its companion object, wire up `extractor`/`renderer` using the smallest combinator that
+   matches its field shape (count of single-valued fields, count of `Seq`-valued fields, aux or
+   not) — if the exact arity/shape doesn't exist yet, extend the ladder by one rung rather than
+   inventing something new.
+3. If it's a new concrete subtype of an existing polymorphic abstraction (`Feature`, `Geometry`,
+   ...), add it to that abstraction's `multiExtractorN`/`rendererSuperN` call — bump `N` by one and
+   add its tag to the label list, in document order.
+4. Watch for the two most common per-field surprises: a bare `Double` field used as a plain child
+   element (the shared `doubleRenderer` always renders attribute-shaped text — wrap it in its own
+   dedicated single-field class, matching `Rotation`/`Range`/`Heading`/etc.), and a field name that
+   happens to look plural but is actually singular (`Plural.unapply`'s `singularEndsInS` exception
+   list; add your case there rather than renaming the field away from its real tag).
+5. Test it against a real file if one exists (or is easy to construct) before trusting a synthetic
+   one — see "Testing philosophy" above.

--- a/README.md
+++ b/README.md
@@ -9,16 +9,62 @@
 
 # XmlDoc
 
-A Scala toolkit for reading, writing, and manipulating XML-based document formats. Originally named
-KmlDoc and focused solely on KML, it's now split into a generic `core` module (XML parsing,
-extraction, and rendering utilities) and format-specific modules built on top of it — currently
-`kml`, for parsing, doctoring, and rendering KML files, with further formats (e.g. IDML) planned.
+A Scala 3 toolkit for reading, writing, and round-tripping XML-based document formats. Originally
+named KmlDoc and focused solely on KML, it's now split into a generic `core` module (typed
+extraction and rendering, plus a generic fallback representation for content that isn't worth
+modeling as its own type) and format-specific modules built on top of it.
 
-The reference documentation for KML is here:
-https://developers.google.com/kml/documentation/kmlreference
+See [DESIGN.md](DESIGN.md) for how the extraction/rendering framework actually works — the type
+class hierarchy, the field-naming conventions, the combinator "arity ladder," and the escape
+hatches for irregular real-world XML. This README covers what the modules are and how to use them.
 
-Versions
-========
+## Modules
+
+| Module | Artifact | Status |
+|---|---|---|
+| [`core`](core) | `xmldoc-core` | Published. Format-agnostic: the `Extractor[T]`/`Renderer[T]` framework, `GenericElement` (generic XML tree), `Zip` helpers. |
+| [`kml`](kml) | `xmldoc-kml` | Published. A fairly complete typed model of the [KML reference](https://developers.google.com/kml/documentation/kmlreference) — extraction, rendering, and simple editing/merging of `.kml` files. |
+| [`kml-it`](kml-it) | not published | Integration tests against real third-party `.kml` files (deliberately not aggregated by the root project, so `sbt test` stays fast). |
+| [`idml`](idml) | not published | Early-stage support for Adobe InDesign's IDML format, built on `core`'s generic representation rather than `kml`'s fully-typed one. Not yet released. |
+
+## Getting started
+
+```scala
+libraryDependencies ++= Seq(
+  "com.phasmidsoftware" %% "xmldoc-core" % "<latest>",
+  "com.phasmidsoftware" %% "xmldoc-kml" % "<latest>"
+)
+```
+
+(see the Maven Central badges above for the current published version).
+
+```scala
+import com.phasmidsoftware.xmldoc.kml.*
+import com.phasmidsoftware.xmldoc.xml.Extractor.extractMulti
+import scala.xml.XML
+import scala.util.Success
+
+val xml = XML.loadFile("sample.kml")
+extractMulti[Seq[KML]](xml) match {
+  case Success(kmls) => kmls.foreach(println)
+  case scala.util.Failure(x) => x.printStackTrace()
+}
+```
+
+Round-tripping (extract, then render back to XML) is exercised extensively in the test suites —
+see `kml/src/test/scala/.../KmlSpec.scala` for realistic examples, including editing/merging
+`Placemark`s.
+
+## Versions
+
+Version 1.1.0 Split into `core`/`kml`/`kml-it` modules; renamed KmlDoc → XmlDoc; published to
+Maven Central. `idml` module added (early stage, unreleased). The `kml` round-trip tests were
+found to be silently non-functional (they never actually re-parsed rendered output), and fixing
+that surfaced several genuine bugs, including a gap in the original #19 fix (an empty self-closing
+element still crashed extraction) plus Issues #20, #21, #27, #29, #44, #51 — see the
+[issue tracker](https://github.com/rchillyard/XmlDoc/issues?q=is%3Aissue+is%3Aclosed) for details
+on each.
+
 Version 1.0.5 Migrate to Scala 3, ...
 
 Version 1.0.4 Many issues fixed. All non-gx entities are implemented now.
@@ -30,7 +76,3 @@ Version 1.0.2 Improvements to rendering and extraction with more KML objects pos
 Version 1.0.1 Improvements: first round-trip extract/render of minisample.kml
 
 Version 1.0 Preliminary work. Most of the functionality is working but there is much still to do, especially for the KML_Samples.kml file.
-
-
-
-

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,91 @@
+# TODO: open, extensible dispatch for unmodeled/future element types
+
+Design discussion from 2026-08-12, not yet implemented. Recorded here so the reasoning survives
+until it's actually built. See [DESIGN.md](DESIGN.md) for how the current (closed) dispatch works.
+
+## Motivation
+
+Two related problems, both stemming from the same root cause:
+
+1. **Issue #52**: Google's `gx:` namespace adds several elements (`gx:Track`,
+   `gx:MultiTrack`, `gx:Tour`, `gx:LatLonQuad`, ...) that aren't worth fully modeling as their own
+   case classes (see the #29 discussion — no real file to verify a specialist implementation
+   against, so `GenericElement` is the right default treatment for now).
+2. **The general case**: KML (or any format) keeps evolving, and a consumer of this library will
+   always encounter *some* element XmlDoc doesn't model yet. Today, an unrecognized tag inside a
+   polymorphic `Seq[Feature]`/`Seq[Geometry]` is silently dropped — `orderedMultiExtractor`'s
+   lookup table just filters it out (see the `KmlSamplesFuncSpec` test titled "...silently skip
+   the unsupported Schema element"). That's lossy, and a library consumer has no way to intervene
+   short of forking the library.
+
+The fix for both is the same: make "not one of the built-in subtypes" a **first-class, non-lossy
+outcome** (fall back to `GenericElement`, don't drop the data), and make that fallback **overridable**
+by a consumer who wants a real, custom typed extractor/renderer for a specific tag instead — without
+forking XmlDoc.
+
+## Design
+
+### 1. A catch-all wrapper per polymorphic hierarchy
+
+Each closed, sealed-trait-like abstraction (`Feature`, `Geometry`, `StyleSelector`,
+`AbstractView`, ...) gets one additional member wrapping a `GenericElement`, e.g.:
+
+```scala
+case class UnknownFeature(element: GenericElement) extends Feature
+case class UnknownGeometry(element: GenericElement) extends Geometry
+```
+
+This is what an unrecognized tag becomes, instead of vanishing. **Behavior change, on purpose**:
+double check `KmlSamplesFuncSpec`'s "silently skip the unsupported Schema element" test (and any
+other test relying on today's silent-drop) still makes sense once "unknown" means "captured
+generically," not "gone."
+
+### 2. An open registry for extraction
+
+Generalizes the `TagProperties` pattern (already used for field-level tag aliases/must-match) up
+to whole-subtype dispatch: a mutable `tag -> Extractor[T]` registry, consulted for any tag not in
+the built-in compile-time list, checked *before* falling back to `UnknownFeature`/`UnknownGeometry`.
+A consumer registers their own `Extractor[GxTrack]` (or whatever) once, and it takes priority over
+the generic fallback for that tag — no fork required.
+
+### 3. An open registry for rendering — this is the harder half
+
+Extraction dispatch is already just a runtime lookup by tag string, so opening it is
+straightforward. Rendering (`rendererSuperN`) is fundamentally different today: it dispatches via
+a **fixed, compile-time list of type parameters**, each checked with `instanceOf` — e.g.
+`rendererSuper6[Feature, Placemark, Container, GroundOverlay, PhotoOverlay, ScreenOverlay,
+NetworkLink]`. A type registered at runtime can't slot into that list. This needs a genuinely
+different, class-keyed runtime lookup (`Map[Class[_], Renderer[_]]`), tried *after* the fixed
+cases and the `UnknownFeature`/`UnknownGeometry` case.
+
+## Recommended sequencing: do Issue #45 first
+
+Issue #45 (build a real `scala.xml.Elem` tree during rendering, instead of assembling text
+character-by-character) isn't required for the above, but it's the right thing to do *first*,
+because it substantially simplifies exactly the code the open-registry design has to touch:
+
+- Today's `StateR`/`Format.formatName`/`doNestedRender` machinery exists purely because rendering
+  hand-assembles indented text. If every `Renderer[T]` instead produced a `scala.xml.Elem`/
+  `NodeSeq`, combining a fixed-dispatch case with an open-registry fallback becomes "collect a
+  `Seq[Elem]`," with `scala.xml`'s own tree composition and pretty-printer handling formatting —
+  no bespoke padding/indent logic left to get wrong when adding a new fallback branch.
+- Bigger structural win: `GenericElement`/`GenericText`/`GenericCData` currently exist as a
+  hand-rolled tree *because* rendering works in strings — they're substantially reimplementing a
+  slice of `scala.xml.Node`. With tree-based rendering, the "unknown element" fallback might not
+  need `GenericElement` for the render direction at all — just hold onto the originally-parsed
+  `scala.xml.Node` and splice it back into the output tree unchanged. That removes a whole layer
+  of duplicated modeling, not just some plumbing.
+
+So: #45 doesn't solve the open-dispatch design by itself, but the open-registry work should land
+on top of it, not underneath it.
+
+## Suggested order of work
+
+1. Issue #45: rendering produces `scala.xml.Elem`/`NodeSeq` instead of `String`.
+2. `UnknownFeature`/`UnknownGeometry` (and siblings for other hierarchies as needed) — verify
+   against real files, and re-check the "silently skip" test's assumptions.
+3. Open extraction registry (tag -> `Extractor[T]`), generalizing `TagProperties`.
+4. Open render registry (`Class[_] -> Renderer[T]`), now straightforward given step 1.
+5. Only then: implement `gx:Track`/`gx:MultiTrack`/`gx:Tour`/`gx:LatLonQuad` support as the first
+   real consumer of this mechanism — generic by default, overridable by anyone who wants a real
+   typed `gx:Track`.

--- a/TODO.md
+++ b/TODO.md
@@ -89,3 +89,42 @@ on top of it, not underneath it.
 5. Only then: implement `gx:Track`/`gx:MultiTrack`/`gx:Tour`/`gx:LatLonQuad` support as the first
    real consumer of this mechanism — generic by default, overridable by anyone who wants a real
    typed `gx:Track`.
+
+## TODO: rename `merge`/`Mergeable` to `join`/`Joinable` (or similar) before Kaining's 3-way merge work
+
+Design discussion from 2026-08-13. Motivation: Kaining's IDML three-way-merge research project
+(the original reason `core`/`idml` exist at all — see [DESIGN.md](DESIGN.md)) is going to need a
+genuine 3-way merge operation (reconcile two independent edits against a common ancestor). That's
+a fundamentally different operation from what `core.Mergeable[T]`/`.merge` currently means
+throughout `kml` — combining two *adjacent, same-named* things into one (e.g. two `LineString`s
+that share an endpoint, two `Placemark`s with the same name). Issue #54's own title ("merging line
+strings") already used the more accurate word first: this is really a **join**, not a merge —
+and `KmlEdit.JOIN`/`JOINX` already use exactly that term for the editing operation that calls
+`.merge()` under the hood. Keeping "merge" for both this 2-way join operation *and* Kaining's
+future 3-way reconciliation would be genuinely confusing once both exist side by side.
+
+**Scope, if we do this** — it's bigger than it first looks:
+
+- `core.Mergeable[T]` (the trait itself) and its companion helpers: `mergeSequence`,
+  `mergeOptions`, `mergeOptionsBiased`, `mergeStrings`, `mergeStringsDelimited`. (`joinOrdered`,
+  added for #54, is already named correctly and needs no change.)
+- Every `.merge` implementation across `kml`: `Text`, `Coordinate`, `Coordinates`, `GeometryData`,
+  `FeatureData`, `LineString`, `Placemark`, and others — dozens of call sites in both main and test
+  sources.
+- **`core` is already published to Maven Central (1.1.0)** — renaming `Mergeable[T]`/`.merge` there
+  is a real breaking API change for anyone depending on `xmldoc-core`, not a cosmetic rename.
+
+**Open decision, worth making deliberately rather than assuming**: does the rename need to touch
+`core.Mergeable` itself, or only `kml`'s usage/vocabulary? Kaining's 3-way merge might end up
+living entirely in `idml` with its own name regardless (e.g. `ThreeWayMerge`/`reconcile`), in which
+case renaming `kml`'s 2-way operation to `join`/`Joinable` — possibly *without* renaming `core`'s
+underlying trait, or by adding a `join` alias alongside `merge` — could resolve the confusion
+without breaking `core`'s published API at all. Worth revisiting once Kaining's own design is
+concrete enough to know what vocabulary it actually needs, rather than renaming twice.
+
+**Context for why this matters as much as it does**: the KML "join" functionality (`KmlEdit.JOIN`)
+was, by Robin's own account, the *original* motivating reason for doing any of the `kml`-module
+work in this project at all — Google Maps' KML export UI tends to fragment a single logical route
+into dozens of separate `Placemark`/`LineString` pairs (e.g. "Historic New England Railroads
+(North).kml"), and the goal was a reliable, semi-automatic way to stitch them back into correct,
+contiguous lines. Issue #54's fix is the thing that actually finishes that original goal.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / organization := "com.phasmidsoftware"
 
-ThisBuild / version := "1.1.1"
+ThisBuild / version := "1.1.2"
 
 ThisBuild / scalaVersion := "3.8.4"
 

--- a/core/src/main/scala/com/phasmidsoftware/xmldoc/core/Mergeable.scala
+++ b/core/src/main/scala/com/phasmidsoftware/xmldoc/core/Mergeable.scala
@@ -82,4 +82,33 @@ object Mergeable {
    * @return an Option[String].
    */
   def mergeStringsDelimited(ao: Option[String], bo: Option[String])(delimiter: String): Option[String] = mergeOptions(ao, bo)((a, b) => Some(s"$a$delimiter$b"))
+
+  /**
+   * Method to join two ordered sequences of elements at whichever end of `second` attaches more
+   * closely to the end of `first`, per the given `distance` function - without ever reversing (or
+   * reordering) `first`: its own orientation is authoritative, and it always comes first in the
+   * result. Only `second` may be reversed, if that yields a closer join.
+   *
+   * This is deliberately generic (not tied to geometry, or to any particular element type): the
+   * only thing it needs to know about `A` is how far apart two instances of it are, if that's even
+   * defined (e.g. Issue #54 uses `Coordinate.distance`, but any "ordered sequence of things with a
+   * distance/compatibility notion between them" can reuse this).
+   *
+   * @param first    the first sequence: appended as-is, never reversed, never reordered.
+   * @param second   the second sequence: appended as-is, or reversed - whichever end attaches more
+   *                 closely to `first`'s last element. If `distance` is undefined for both
+   *                 candidate joins (or either sequence is empty), `second` is appended as-is.
+   * @param distance a function yielding the distance between two elements, if defined.
+   * @tparam A the element type.
+   * @return the concatenation of `first` and (possibly-reversed) `second`.
+   */
+  def joinOrdered[A](first: Seq[A], second: Seq[A])(distance: (A, A) => Option[Double]): Seq[A] =
+    (first.lastOption, second.headOption, second.lastOption) match {
+      case (Some(a), Some(b0), Some(b1)) =>
+        (distance(a, b0), distance(a, b1)) match {
+          case (Some(asIs), Some(reversed)) if reversed < asIs => first ++ second.reverse
+          case _ => first ++ second
+        }
+      case _ => first ++ second
+    }
 }

--- a/kml/src/main/scala/com/phasmidsoftware/xmldoc/kml/KML.scala
+++ b/kml/src/main/scala/com/phasmidsoftware/xmldoc/kml/KML.scala
@@ -778,18 +778,20 @@ case class Coordinates(coordinates: Seq[Coordinate]) extends Mergeable[Coordinat
   /**
    * Merges this `Coordinates` instance with another `Coordinates` instance.
    *
+   * The result is oriented the same way as `this` (this's own direction is authoritative and it
+   * always comes first) - `other` is attached at whichever of its own ends is closer to this
+   * one's last coordinate, reversing it first if that yields a closer join (Issue #54: previously,
+   * this only ever compared the two straight concatenations, this++other vs other++this, so a
+   * pair of lines that should join end-to-end or start-to-start - needing a reversal - was never
+   * actually found).
+   *
    * @param other     the other `Coordinates` instance to be merged with this instance.
    * @param mergeName a boolean indicating whether to merge the names of the two `Coordinates` instances. Defaults to true.
    * @return an `Option` containing the resulting merged `Coordinates`, or `None` if the merge cannot be performed.
    */
   infix def merge(other: Coordinates, mergeName: Boolean = true): Option[Coordinates] = {
     KMLCompanion.logger.info(s"merge $this with $other")
-    // CONSIDER rejuvenating the following code to try to deal automatically with inversions.
-//    val xo = vector
-//    val yo: Option[Cartesian] = other.vector
-//    val zo: Option[Double] = for (x <- xo; y <- yo) yield x dotProduct y
-//    val q: Option[Coordinates] = for (z <- zo) yield if (z >= 0) other else other.reverse // no longer used
-    mergeInternal(Some(other))
+    Some(Coordinates(Mergeable.joinOrdered(coordinates, other.coordinates)((a, b) => a distance b)))
   }
 
   /**
@@ -817,22 +819,6 @@ case class Coordinates(coordinates: Seq[Coordinate]) extends Mergeable[Coordinat
       b <- cs2.headOption
       q <- a.distance(b)
     } yield q
-
-  /**
-   * Merges the current `Coordinates` instance with another optional `Coordinates` instance.
-   * The merge operation is based on a comparison of distances (gaps) between the current
-   * and the provided `Coordinates` instances.
-   *
-   * @param co an `Option` containing the `Coordinates` instance to be merged with the current instance
-   * @return an `Option` containing the resulting merged `Coordinates`, or `None` if the merge cannot be performed
-   */
-  private def mergeInternal(co: Option[Coordinates]): Option[Coordinates] =
-    for {
-      c <- co
-      r <- gap(c)
-      s <- c.gap(this)
-    } yield
-      Coordinates(if (r < s) coordinates ++ c.coordinates else c.coordinates ++ coordinates)
 }
 
 /**

--- a/kml/src/test/scala/com/phasmidsoftware/xmldoc/kml/KmlSpec.scala
+++ b/kml/src/test/scala/com/phasmidsoftware/xmldoc/kml/KmlSpec.scala
@@ -5206,13 +5206,13 @@ class KmlSpec extends AnyFlatSpec with should.Matchers {
   }
 
   it should "merge Placemarks 2" in {
+    // Issue #54: the result is oriented the same way as the first-mentioned operand (p2, here) -
+    // it's never reordered or reversed itself; only the other operand (p1) may be reversed, if
+    // that attaches more closely to p2's own last coordinate (it does here).
     val maybePlacemark = p2 merge p1
     maybePlacemark.isDefined shouldBe true
     val pz = maybePlacemark.get
-    pz.Geometry.head match {
-      case LineString(_, cs) => cs shouldBe Seq(Coordinates(cs1 ++ cs2))
-    }
-    pz shouldBe p12
+    pz shouldBe Placemark(Seq(LineString(Some(tessellate), Seq(Coordinates(cs2 ++ cs1.reverse)))(gd)))(fd2)
   }
 
   it should "leave all Placemarks unchanged when a JOIN's second name matches nothing (Issue #20)" in {
@@ -5228,18 +5228,20 @@ class KmlSpec extends AnyFlatSpec with should.Matchers {
     result shouldBe fs
   }
 
-//  it should "merge Placemarks 3" in {
-//    val maybePlacemark = p1 merge p2a
-//    maybePlacemark.isDefined shouldBe true
-//    val pz = maybePlacemark.get
-//    pz shouldBe p12
-//  }
-//
-//  it should "merge Placemarks 4" in {
-//    val maybePlacemark = p2a merge p1
-//    maybePlacemark.isDefined shouldBe true
-//    val pz = maybePlacemark.get
-//    pz shouldBe p12a
-//  }
+  it should "merge Placemarks 3 (Issue #54: p2a's coordinates are reversed relative to p2)" in {
+    // p2a is cs2 reversed - the fix must detect that p2a needs re-reversing to attach to p1
+    // correctly, rather than only ever trying the two straight (unreversed) concatenations.
+    val maybePlacemark = p1 merge p2a
+    maybePlacemark.isDefined shouldBe true
+    val pz = maybePlacemark.get
+    pz shouldBe p12
+  }
+
+  it should "merge Placemarks 4 (Issue #54: same as 3, but with the operands swapped)" in {
+    val maybePlacemark = p2a merge p1
+    maybePlacemark.isDefined shouldBe true
+    val pz = maybePlacemark.get
+    pz shouldBe p12a
+  }
 }
 


### PR DESCRIPTION
README now accurately reflects the current module lineup (idml/kml-it status checked directly against Maven Central) and links to a proper design doc.

DESIGN.md captures the extraction/rendering framework - field-naming conventions, the arity ladder, MultiExtractor polymorphic dispatch, the auxiliary-parameter pattern, the TagProperties/GenericElement escape hatches, and the round-trip-against-real-files testing philosophy - written now while it is all still fresh, for whoever adds the next element type.

Fixes #54 